### PR TITLE
Drop jna dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,6 @@ sbtPlugin := true
 pluginCrossBuild / sbtVersion := "1.3.9" // minimum version we target
 
 libraryDependencies ++= Seq(
-  "net.java.dev.jna" % "jna" % "5.10.0",
   "org.scalatest" %% "scalatest" % "3.2.11" % Test
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ developers := List(
 
 enablePlugins(SbtPlugin)
 sbtPlugin := true
-pluginCrossBuild / sbtVersion := "1.3.9" // minimum version we target
+pluginCrossBuild / sbtVersion := "1.3.9" // minimum version we target because of using Native.load, see https://github.com/Philippus/sbt-dotenv/issues/81
 
 libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.2.11" % Test


### PR DESCRIPTION
Because actually sbt-dotenv is using jna transitively through sbt, there's no need to add jna as a dependency and it's less confusing.