### PR TITLE
Cross-build for sbt 2.0.0-M2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,4 +14,4 @@ jobs:
           distribution: temurin
           java-version: 8
       - name: Run tests
-        run: sbt clean test scripted
+        run: sbt clean +test +scripted

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,16 @@ developers := List(
 )
 
 enablePlugins(SbtPlugin)
-pluginCrossBuild / sbtVersion := "1.3.9" // minimum version we target because of using Native.load, see https://github.com/Philippus/sbt-dotenv/issues/81
+
+scalaVersion := "2.12.20"
+crossScalaVersions += "3.3.4"
+
+pluginCrossBuild / sbtVersion := {
+  scalaBinaryVersion.value match {
+    case "2.12" => "1.5.8"
+    case _      => "2.0.0-M2"
+  }
+}
 
 libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.2.19" % Test

--- a/src/main/scala/au/com/onegeek/sbtdotenv/SbtDotenv.scala
+++ b/src/main/scala/au/com/onegeek/sbtdotenv/SbtDotenv.scala
@@ -27,7 +27,7 @@ import scala.io.Source
   *
   * Reads a file
   */
-object SbtDotenv extends AutoPlugin {
+object SbtDotenv extends AutoPlugin with SlashSyntax {
 
   object autoImport {
     lazy val envFileName         =

--- a/src/sbt-test/sbt-dotenv/check-load-on-demand-dot-env/test
+++ b/src/sbt-test/sbt-dotenv/check-load-on-demand-dot-env/test
@@ -8,7 +8,7 @@
 
 > checkTest
 
-> it:test
+> IntegrationTest / test
 
 > checkIntegrationTest
 


### PR DESCRIPTION
Applying this PR will enable cross-build for sbt 2.0.0-M2. Had to set the minimum sbt version to 1.5.8.